### PR TITLE
Change targetType from 'sourceLibrary' to the implicit 'library'.

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -4,6 +4,5 @@
 	"authors": ["Tero Hänninen"],
 	"license": "BSL-1.0",
 	"importPaths": ["."],
-	"sourceFiles": ["imageformats.d"],
-	"targetType": "sourceLibrary"
+	"sourceFiles": ["imageformats.d"]
 }


### PR DESCRIPTION
I'm not confident about using `sourceLibrary` in DUB.
For one, IDE projects generated by DUB for Sublime Text or VisualD don't show the imageformats source files.
Secondly, the advantage of compiling all-at-once are still there with `--combined`.
