### PR TITLE
Add transparency support for paletted png files

### DIFF
--- a/imageformats/png.d
+++ b/imageformats/png.d
@@ -269,7 +269,7 @@ Buffer decode_png(ref PNG_Decoder dc) {
                       (stage == Stage.PLTE_parsed && dc.src_indexed)) )
                     throw new ImageIOException("corrupt chunk stream");
                 if (dc.src_indexed) {
-                    ulong entries = dc.palette.length / 3;
+                    size_t entries = dc.palette.length / 3;
                     if (len > entries)
                         throw new ImageIOException("corrupt chunk");
                 }

--- a/imageformats/png.d
+++ b/imageformats/png.d
@@ -268,9 +268,11 @@ Buffer decode_png(ref PNG_Decoder dc) {
                 if (! (stage == Stage.IHDR_parsed ||
                       (stage == Stage.PLTE_parsed && dc.src_indexed)) )
                     throw new ImageIOException("corrupt chunk stream");
-                ulong entries = dc.palette.length / 3;
-                if (len > entries)
-                    throw new ImageIOException("corrupt chunk");
+                if (dc.src_indexed) {
+                    ulong entries = dc.palette.length / 3;
+                    if (len > entries)
+                        throw new ImageIOException("corrupt chunk");
+                }
                 dc.transparency = new ubyte[len];
                 dc.stream.readExact(dc.transparency, dc.transparency.length);
                 dc.stream.readExact(dc.chunkmeta, 12);


### PR DESCRIPTION
The changes add support for the tRNS chunk, but only applies the transparency information to paletted png files.

Transparency information can be read from the dc.transparency array for adding support to other formats (grayscale, truecolor).